### PR TITLE
fix: バスケット画面と座席番号入力モーダルの入力規制を修正

### DIFF
--- a/front/pages/tableorder/basket.vue
+++ b/front/pages/tableorder/basket.vue
@@ -45,9 +45,7 @@
                             outlined
                             height="56"
                             min="0"
-                            max="99"
                             v-model="order.count"
-                            oninput="if(Number(this.value) < Number(this.min)) this.value = this.min;if(Number(this.value) > Number(this.max)) this.value = this.max;"
                             v-on:change="modify(order)"
                         ></v-text-field>
                     </div>
@@ -190,7 +188,7 @@ export default {
         orderEnabled() {
             // 注文ボタン活性制御
             for(const orderNo in this.orders) {
-                if(this.orders[orderNo].count === 0) {
+                if(this.orders[orderNo].count < 1) {
                     return false;
                 }
             }
@@ -256,9 +254,13 @@ export default {
          * @param {Object} order 商品情報
          */
         modify(order) {
-            if ( order.count <= 0 || isNaN(order.count) ) {
+            if(Number(order.count) > 99) {
+                order.count = 99;
+            }
+            if ( order.count < 1 || isNaN(order.count) ) {
                 order.count = 1;
             }
+            order.count = Math.floor(order.count)
             
             const categoryId = order.categoryId;
             const itemId = order.itemId;

--- a/front/pages/tableorder/menu/_seatNo.vue
+++ b/front/pages/tableorder/menu/_seatNo.vue
@@ -143,12 +143,14 @@
                 <v-card-title class="justify-center">{{ $t("menu.msg009") }}</v-card-title>
                 <v-card-actions>
                     <v-spacer></v-spacer>
-                    <v-text-field 
-                        regular
-                        v-bind:label="$t('menu.msg010')" 
-                        v-bind:rules="[required, numberOnly]"
-                        class="mr-3 mt-3" style="width: 50px;" 
-                        v-model="seatNo"></v-text-field>
+                    <v-form ref="seatNoForm">
+                        <v-text-field 
+                            regular
+                            v-bind:label="$t('menu.msg010')" 
+                            v-bind:rules="[required, numberOnly]"
+                            class="mr-3 mt-3" style="width: 100px;" 
+                            v-model="seatNo"></v-text-field>
+                    </v-form>
                     <v-btn tile color="#00B900" class="px-5 white--text text-body-1 font-weight-bold" v-on:click="setSeatNo()">{{ $t("menu.msg011") }}</v-btn>
                     <v-spacer></v-spacer>
                 </v-card-actions>
@@ -284,11 +286,11 @@ export default {
          * 
          */
         setSeatNo() {
-            if (!String(this.customer.seatNo).match(/^[0-9]*$/g)) {
-                this.seatNoModal = true;
+            if (this.$refs.seatNoForm.validate()) {
+                this.seatNoModal = false;
                 return;
             }
-            this.seatNoModal = false;
+            this.seatNoModal = true;
         },
         /**
          * 商品カテゴリー検索


### PR DESCRIPTION
### 修正概要
バスケット画面　商品個数入力欄(front/pages/tableorder/basket.vue)
・小数点を入力できないようにしました。
・iOSで負の数を入力したときの挙動を修正しました。

座席番号入力モーダル(front/pages/tableorder/menu/_seatNo.vue)
・未入力で設定できないように修正しました。